### PR TITLE
Pin Apple dependency versions to prevent Package.resolved drift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,9 @@ let package = Package(name: "opentelemetry-swift",
                         .library(name: "DataCompression", type: .static, targets: ["DataCompression"]),
                       ],
                       dependencies: [
-                        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.20.2"),
-                        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
-                        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
+                        .package(url: "https://github.com/apple/swift-protobuf.git", exact: "1.33.1"),
+                        .package(url: "https://github.com/apple/swift-log.git", exact: "1.6.3"),
+                        .package(url: "https://github.com/apple/swift-atomics.git", exact: "1.3.0")
                       ],
                       targets: [
                         .target(name: "OpenTelemetryApi",


### PR DESCRIPTION
## Problem

POS Mobile's `Package.resolved` changes every time `xcodebuild` triggers SPM re-resolution. The committed file had `swift-log` pinned to commit `2778fd4` (actually tagged `1.9.1`) but labeled as version `1.6.3`. Any re-resolution corrects this mismatch, dirtying the file.

I believe the root cause is the loose `from:` constraints on the three Apple dependencies. These allow SPM to resolve different versions depending on Xcode version, Swift toolchain, and resolver state. For example, `swift-log` 1.7.0+ requires `swift-tools-version:6.0`, so older toolchains cap at 1.6.x while newer ones can pick 1.9.x or higher.

## Fix

Pin all three Apple dependencies to exact versions matching what currently resolves correctly:

- `swift-protobuf` 1.33.1 (latest version before Apple bumped to `swift-tools-version:6.2` in 1.33.2)
- `swift-log` 1.6.3
- `swift-atomics` 1.3.0

This ensures every consumer resolves to the same versions regardless of their Xcode/Swift version, eliminating the Package.resolved churn.

## CI failures

The failing CI jobs are all pre-existing issues unrelated to this change:

- **Linux**: The reduced fork has no `Tests` directory, so `swift test` fails with `no tests found`. The build itself succeeds.
- **iOS / tvOS / watchOS**: The Makefile hardcodes simulator destinations (e.g. `iPhone 16,OS=18.0`) that don't exist on the current macOS-15 runner. SPM resolution and compilation succeed, but xcodebuild can't find matching devices.

The macOS job (which builds and runs tests successfully) validates that the pinned versions resolve and compile correctly.